### PR TITLE
docs: add issues and PR templates in .github

### DIFF
--- a/.github/ISSUE_TEMPLATE/propose-feat.md
+++ b/.github/ISSUE_TEMPLATE/propose-feat.md
@@ -1,0 +1,15 @@
+---
+name: Propose feature
+about: Suggest new functionality
+title: "New feat"
+labels: feat
+assignees: ""
+---
+### Reason
+<!-- A short and clear explanation of why this feature is needed. Example: I'm concerned about the user experience on the registration screen... -->
+
+### Objective
+<!-- A short and clear description of the goal of this feature. Example: Solve issues with slow loading of bands on the registration screen... -->
+
+### Describe alternatives you've considered
+<!-- Other solutions you considered to implement this feature. Example: "At first, I thought about creating..." --> <!-- **Additional context** Any extra information related to the feature. -->

--- a/.github/ISSUE_TEMPLATE/propose-refact.md
+++ b/.github/ISSUE_TEMPLATE/propose-refact.md
@@ -1,0 +1,20 @@
+---
+name: Propose refactor
+about: Suggest improvements to a piece of code
+title: "Proposing a refactor!"
+labels: refact
+assignees: ""
+---
+What is the current state of the code?
+
+<!-- A clear and concise description of how the code currently works and why it should be refactored. If possible, include the relevant code snippet. -->
+What should it look like after the refactor?
+
+<!-- A clear and concise description of how the code should look after the refactor. If possible, include the updated code snippet. -->
+Expected outcome
+
+<!-- A clear and concise explanation of what should improve as a result of this refactor. Example: Page performance should increase, as reflected in Vercel Analytics. -->
+Additional context
+
+<!-- Add any extra information relevant to the refactor. -->
+

--- a/.github/ISSUE_TEMPLATE/report-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-bug.md
@@ -1,0 +1,41 @@
+---
+name: Report bug
+about: Something isn't working correctly
+title: "New bug found"
+labels: bug
+assignees: ""
+---
+
+**Bug description**
+
+<!--  
+  A clear and concise description of the bug.  
+-->
+
+**How to reproduce**
+
+<!--  
+  Step-by-step instructions to reproduce the issue:  
+-->
+
+1. Go to '...'
+2. Click on '...'
+
+**Expected behavior**
+
+<!--  
+  A clear and concise description of what you expected to happen.  
+-->
+
+**Screenshots**
+
+<!--  
+  If possible, include screenshots to help illustrate the issue.  
+-->
+
+**Additional context**
+
+<!--  
+  Add any other information relevant to the bug.  
+-->
+

--- a/.github/not-ready-worflows/backend.yml
+++ b/.github/not-ready-worflows/backend.yml
@@ -1,0 +1,76 @@
+name: Backend CI
+run-name: Running all verifications of backend
+on: [push]
+
+defaults:
+  run:
+    working-directory: ./backend
+
+jobs:
+  changes:
+      runs-on: ubuntu-latest
+      outputs:
+        docs : ${{ steps.filter.outputs.docs }}
+      steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'backend/src/docs/asciidoc/**'
+
+  check:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: borapagar
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21 for x64
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          architecture: x64
+          cache: 'maven'
+      
+      - name: Run verify suit
+        run : ./mvnw verify
+      
+      - name: Check if code is formatted
+        run: ./mvnw spotless:check
+      
+      
+      - name: Upload archive to github pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: backend/target/generated-docs
+
+  deploy-dev-docs:
+    runs-on: ubuntu-latest
+    needs: [check, changes]
+    if: ${{ needs.changes.outputs.docs == 'true' }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+

--- a/.github/not-ready-worflows/backend_test_coverage.yml
+++ b/.github/not-ready-worflows/backend_test_coverage.yml
@@ -1,0 +1,63 @@
+name: Test Coverage
+
+on:
+  pull_request:
+    paths:
+      - "backend/**"
+
+defaults:
+  run:
+    working-directory: ./backend
+
+jobs:
+  
+ test-coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: borapagar
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 21 for x64
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          architecture: x64
+          cache: 'maven'
+      
+      - name: Generate test coverage
+        run: ./mvnw test
+
+      - name: Add coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          paths: |
+            ${{ github.workspace }}/backend/target/site/jacoco/jacoco.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 40
+          min-coverage-changed-files: 60
+          title: '# Test coverage :test_tube:'
+          update-comment: true
+          pass-emoji: ':ok_hand:'
+          fail-emoji: ':skull_and_crossbones:'
+
+      - name: Informs that PR has fail when coverage is less then 40%
+        if: ${{ steps.jacoco.outputs.coverage-overall < 40.0 }}
+        uses: actions/github-script@v6
+        with:
+            script: |
+                core.setFailed('Cobertura geral é menor que 40%!')

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+**Please confirm that this PR meets the required standards:**
+
+<!--- Example of a checked box: - [x] -->
+
+* [ ] Follows the project’s code style
+* [ ] Changed/added files use *CamelCase* naming
+* [ ] This PR is linked to one or more issues
+
+**What motivated this PR**
+
+<!--- Briefly and clearly explain the reason for this PR below. -->
+
+**What was done**
+
+<!---  
+  If there were many changes, please summarize them below.  
+  Example:  
+    - A perfectly crafted açaí bowl  
+    - A landing page  
+    - A beat that makes you dance  
+-->
+
+**Screenshots**
+
+<!---  
+  REMOVE IF NOT USED.  
+  If possible, include images that illustrate the work done.  
+-->
+
+**What’s missing or could be improved**
+
+<!---  
+  REMOVE IF NOT USED.  
+  Mention any aspects that could be further developed or improved in relation to this PR.  
+-->


### PR DESCRIPTION
## What was done
- Issues templates for feat, refact and bug report
- PR template to general use
- Actions template added in the `not-ready-worflows` folder, name was changed so it can be set latter